### PR TITLE
refact: 에러 핸들러 리턴값을 DTO로 변경

### DIFF
--- a/server/src/main/java/com/nonstop/playground/common/config/BaseControllerAdvice.java
+++ b/server/src/main/java/com/nonstop/playground/common/config/BaseControllerAdvice.java
@@ -29,16 +29,16 @@ public class BaseControllerAdvice {
     }
 
     @ExceptionHandler(BaseException.class)
-    public <T extends BaseException> ResponseEntity<BaseException> handleBaseException(T customException) {
+    public <T extends BaseException> ResponseEntity<ExceptionDTO> handleBaseException(T customException) {
         log.error(customException.getClassName() + "is occurred!", customException);
 
-        return ResponseEntity.status(customException.getHttpStatus()).body(customException);
+        return ResponseEntity.status(customException.getHttpStatus()).body(new ExceptionDTO(customException));
     }
 
     @ExceptionHandler(Exception.class)
-    public ResponseEntity<Exception> handleUnexpectedException(Exception exception) {
+    public ResponseEntity<ExceptionDTO> handleUnexpectedException(Exception exception) {
         log.error("Unexpected exception is occurred!", exception);
 
-        return ResponseEntity.internalServerError().body(exception);
+        return ResponseEntity.internalServerError().body(new ExceptionDTO(exception));
     }
 }

--- a/server/src/main/java/com/nonstop/playground/common/config/ExceptionDTO.java
+++ b/server/src/main/java/com/nonstop/playground/common/config/ExceptionDTO.java
@@ -1,0 +1,22 @@
+package com.nonstop.playground.common.config;
+
+import com.nonstop.playground.common.exception.BaseException;
+import lombok.Data;
+
+@Data
+public class ExceptionDTO {
+
+    private final String errorCode;
+
+    private final String message;
+
+    public ExceptionDTO(Exception exception) {
+        this.errorCode = "UNKNOWN";
+        this.message = exception.getMessage();
+    }
+
+    public ExceptionDTO(BaseException baseException) {
+        this.errorCode = baseException.getErrorCode();
+        this.message = baseException.getMessage();
+    }
+}


### PR DESCRIPTION
# 무엇을 해결하려고 하셨나요?
* 에러 핸들링 됬을때 에러 트레이스 전부가 리턴되어 가는 문제

# 어떻게 해결하셨나요?
* 에러 핸들러의 반환값을 DTO 변경하여 필요한 값만 리턴하는걸로 수정